### PR TITLE
Fix Stockfish bestmove not ignore pawn promote move

### DIFF
--- a/api/constants.ts
+++ b/api/constants.ts
@@ -1,6 +1,6 @@
 export const LICHESS_OPENING_URL = "https://explorer.lichess.ovh/master";
 export const LICHESS_CLOUD_EVAL_URL = "https://lichess.org/api/cloud-eval";
-export const PATTERN_UCI_MOVE = /^((a|b|c|d|e|f|g|h)(1|2|3|4|5|6|7|8)){2}$/;
+export const PATTERN_UCI_MOVE = /^((a|b|c|d|e|f|g|h)(1|2|3|4|5|6|7|8)){2}q?$/;
 
 export const MIN_MULTI_PV = 1;
 export const MAX_MULTI_PV = 20;


### PR DESCRIPTION
If Stockfish best move is pawn promotion It contains one letter which express promote piece like this

info depth 1 seldepth 1 multipv 1 score cp 6105 nodes 11 nps 1375 time 8 pv *`h7h8q`* bmc 0
info depth 2 seldepth 2 multipv 1 score cp 6100 nodes 36 nps 2400 time 15 pv *`h7h8q` b7a6* bmc 0

but original regex pattern didn't catch this moves and not add to bestmove line
it makes very weird result like this
```
fen = '8/1k5P/8/3K4/8/8/8/8 w - - 3 6'
const {
  chessAnalysisApi,
  PROVIDERS
} = require('chess-analysis-api')

async function main() {
  const data = await chessAnalysisApi.getAnalysis({
    fen: fen,
    depth: 3,
    multipv: 1,
    excludes: [
      PROVIDERS.LICHESS_BOOK,
      PROVIDERS.LICHESS_CLOUD_EVAL
    ]
  })
  console.log(data.moves[0].uci) 
  // result: [ 'b7a6', 'h8h1' ]
}
main()
```
`h7h8q` is skipped and this is white turn but first move `b7a6` is black move 
i think problem is just can be solved by modify regex pattern